### PR TITLE
Correct licence string in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "core/_build/ext/app/electron/main.js",
   "repository": "git@github.com:paulfitz/grist-electron",
   "author": "Paul Fitzpatrick <paulfitz@alum.mit.edu>",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "workspaces": [
     "core",
     "ext"


### PR DESCRIPTION
This just affects the Linux build.

https://www.electron.build/configuration/configuration#metadata