### PR TITLE
Miscellaneous packaging fixes

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-14
+          - macos-13
           - ubuntu-22.04
           - windows-2022
         host:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -120,5 +120,5 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.host }}-${{ matrix.target }}
-          path: dist/grist-electron-*
+          path: dist/grist-desktop-*
           if-no-files-found: "error"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -66,6 +66,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
       - uses: actions/cache@v4
         id: yarn-cache
         with:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -124,5 +124,8 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.os }}-${{ matrix.host }}-${{ matrix.target }}
-          path: dist/grist-desktop-*
+          path: |
+            dist/grist-desktop-*.exe
+            dist/grist-desktop-*.AppImage
+            dist/grist-desktop-*.dmg
           if-no-files-found: "error"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "grist-desktop",
   "productName": "Grist Desktop",
-  "description": "Grist is the evolution of spreadsheets",
+  "description": "Grist Desktop",
   "version": "0.2.9",
   "main": "core/_build/ext/app/electron/main.js",
   "repository": "https://github.com/gristlabs/grist-desktop",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chromedriver": "110.0.0"
   },
   "build": {
-    "appId": "com.electron.grist.core",
+    "appId": "com.getgrist.desktop",
     "npmRebuild": false,
     "compression": "normal",
     "includeSubNodeModules": true,
@@ -52,14 +52,13 @@
           "target": "portable"
         }
       ],
-      "artifactName": "${name}-windows-${version}-${arch}.${ext}",
       "icon": "core/static/icons/grist.ico"
     },
     "portable": {
-      "artifactName": "${productName}-windows-portable-${version}-${arch}.${ext}"
+      "artifactName": "${name}-windows-portable-${version}-${arch}.${ext}"
     },
     "nsis": {
-      "artifactName": "${productName}-windows-installer-${version}-${arch}.${ext}",
+      "artifactName": "${name}-windows-installer-${version}-${arch}.${ext}",
       "perMachine": true
     },
     "mac": {


### PR DESCRIPTION
Addresses "grist-electron" leftovers from #38 and fixes packaging problems. Adds an explicit `setup-python` step to limit Python version to 3.11, as a workaround for https://github.com/actions/runner/issues/2958.