### PR TITLE
Use the `zip` target instead of `portable` for Windows portable builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -133,7 +133,7 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: actions/upload-artifact@v4
         with:
-          name: windows-portable-${{ matrix.target }}
+          name: windows-installer-${{ matrix.target }}
           path: dist/grist-desktop-*.exe
           if-no-files-found: "error"
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -121,11 +121,34 @@ jobs:
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
 
-      - uses: actions/upload-artifact@v4
+      - name: Upload Windows portable build
+        if: startsWith(matrix.os, 'windows')
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os }}-${{ matrix.host }}-${{ matrix.target }}
-          path: |
-            dist/grist-desktop-*.exe
-            dist/grist-desktop-*.AppImage
-            dist/grist-desktop-*.dmg
+          name: windows-portable-${{ matrix.target }}
+          path: dist/grist-desktop-*.zip
+          if-no-files-found: "error"
+
+      - name: Upload Windows installer build
+        if: startsWith(matrix.os, 'windows')
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-portable-${{ matrix.target }}
+          path: dist/grist-desktop-*.exe
+          if-no-files-found: "error"
+
+      - name: Upload Linux build
+        if: startsWith(matrix.os, 'ubuntu')
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-${{ matrix.target }}
+          path: dist/grist-desktop-*.AppImage
+          if-no-files-found: "error"
+
+      - name: Upload macOS build
+        if: startsWith(matrix.os, 'macos')
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-${{ matrix.target }}
+          path: dist/grist-desktop-*.dmg
           if-no-files-found: "error"

--- a/package.json
+++ b/package.json
@@ -49,12 +49,12 @@
           "target": "nsis"
         },
         {
-          "target": "portable"
+          "target": "zip"
         }
       ],
       "icon": "core/static/icons/grist.ico"
     },
-    "portable": {
+    "zip": {
       "artifactName": "${name}-windows-portable-${version}-${arch}.${ext}"
     },
     "nsis": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "includeSubNodeModules": true,
     "icon": "core/static/icons/grist.png",
     "win": {
+      "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
       "target": [
         {
           "target": "nsis"
@@ -54,15 +55,11 @@
       ],
       "icon": "core/static/icons/grist.ico"
     },
-    "zip": {
-      "artifactName": "${name}-windows-portable-${version}-${arch}.${ext}"
-    },
     "nsis": {
-      "artifactName": "${name}-windows-installer-${version}-${arch}.${ext}",
       "perMachine": true
     },
     "mac": {
-      "artifactName": "${name}-mac-${version}-${arch}.${ext}",
+      "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
       "icon": "core/static/icons/grist.icns",
       "category": "public.app-category.developer-tools",
       "hardenedRuntime": true,
@@ -71,7 +68,7 @@
       "entitlementsInherit": "scripts/entitlements.mac.plist"
     },
     "linux": {
-      "artifactName": "${name}-linux-${version}-${arch}.${ext}",
+      "artifactName": "${name}-${version}-${os}-${arch}.${ext}",
       "icon": "core/static/icons/grist.png",
       "target": "AppImage"
     },


### PR DESCRIPTION
The Windows portable build needs to unpack itself every time it launches. This is painfully slow. electron-builder offers a `zip` build target. It might be a better idea than `portable`.

Note that electron-builder does not allow setting the artifact name explicitly for the `zip` target. Workaround is to set the artifact name for all Windows builds, and use the extension name to tell them apart.

Relevant complaint https://community.getgrist.com/t/grist-desktop-portable-on-windows/5656
