### PR TITLE
Disabling tutorials

### DIFF
--- a/ext/app/electron/config.ts
+++ b/ext/app/electron/config.ts
@@ -109,7 +109,7 @@ export async function loadConfig() {
   process.env.GRIST_SERVE_SAME_ORIGIN = "true";
   process.env.GRIST_DEFAULT_PRODUCT = "Free";
   process.env.GRIST_ORG_IN_PATH = "true";
-  process.env.GRIST_HIDE_UI_ELEMENTS = "helpCenter,billing,templates,multiSite,multiAccounts";
+  process.env.GRIST_HIDE_UI_ELEMENTS = "helpCenter,billing,templates,multiSite,multiAccounts,tutorials";
   process.env.GRIST_CONTACT_SUPPORT_URL = packageJson.repository + "/issues";
   if (process.env.GRIST_DESKTOP_AUTH !== "mixed") {
     process.env.GRIST_FORCE_LOGIN = "true";


### PR DESCRIPTION
Tutorials should be a hidden UI element by default in grist-desktop.

Test Plan:
Manual, build grist-desktop in normal way and run `npm run electron:preview`, tutorial
card should be hidden.