### PR TITLE
config: set PYTHON_VERSION_ON_CREATION=3

### DIFF
--- a/ext/app/electron/config.ts
+++ b/ext/app/electron/config.ts
@@ -87,6 +87,11 @@ export async function loadConfig() {
     path.join(electron.app.getPath("home"), ".grist")
   );
   validateOrFallback(
+    "PYTHON_VERSION_ON_CREATION",
+    (ver) => ["2", "3"].includes(ver),
+    "3"
+  );
+  validateOrFallback(
     "TYPEORM_DATABASE",
     NO_VALIDATION,
     path.join(electron.app.getPath("appData"), "landing.db")


### PR DESCRIPTION
This is necessary in order to make newly-created documents on Desktop be marked as being created for Python 3.