### PR TITLE
default to GRIST_SQLITE_MODE=sync on Desktop

### DIFF
--- a/ext/app/electron/config.ts
+++ b/ext/app/electron/config.ts
@@ -101,6 +101,11 @@ export async function loadConfig() {
     NO_VALIDATION,
     commonUrls.gristLabsWidgetRepository
   );
+  validateOrFallback(
+    "GRIST_SQLITE_MODE",
+    (mode) => ["", "sync", "wal"].includes(mode),
+    "sync"
+  );
 
   const homeDBLocation = path.parse(path.resolve(process.env.TYPEORM_DATABASE as string)).dir;
   if (!fse.existsSync(homeDBLocation)) {


### PR DESCRIPTION
For Desktop use, `sync` is a good default setting. For performance, `wal` would be faster while also safe, but results in multiple files per document which would be confusing for those using .grist files directly.