### PR TITLE
do not include optional dependencies

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -82,8 +82,8 @@ jobs:
 
       - name: Install dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install --network-timeout 300000
-      
+        run: yarn install --network-timeout 300000 --ignore-optional
+
       - name: Fix Windows x86 sqlite3 binding
         if: steps.yarn-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows') && matrix.target == 'x86'
         run: yarn upgrade sqlite3


### PR DESCRIPTION
`msgpackr-extract` is a problem on Windows x86, and everything appears to work without optional dependencies? We don't have a test set for this project yet so it is a bit hard to be sure.