### PR TITLE
tweak macos x64 build

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-14
+          - macos-14-large
           - ubuntu-22.04
           - windows-2022
         host:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,6 +8,8 @@ on:
       - '*'
 env:
   FORCE_COLOR: 1
+  # This makes the macos-13 packaging work.
+  # I don't know why. Your guess is as good as mine.
   DEBUG_DMG: true
 concurrency:
   group: ${{ github.head_ref || github.run_id }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-14-large
+          - macos-13
           - ubuntu-22.04
           - windows-2022
         host:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -8,6 +8,7 @@ on:
       - '*'
 env:
   FORCE_COLOR: 1
+  DEBUG_DMG: true
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/package.json
+++ b/package.json
@@ -68,7 +68,11 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "scripts/entitlements.mac.plist",
-      "entitlementsInherit": "scripts/entitlements.mac.plist"
+      "entitlementsInherit": "scripts/entitlements.mac.plist",
+      "target": "dmg"
+    },
+    "dmg": {
+      "writeUpdateInfo": false
     },
     "linux": {
       "artifactName": "${name}-${version}-${os}-${arch}.${ext}",

--- a/package.json
+++ b/package.json
@@ -68,11 +68,7 @@
       "hardenedRuntime": true,
       "gatekeeperAssess": false,
       "entitlements": "scripts/entitlements.mac.plist",
-      "entitlementsInherit": "scripts/entitlements.mac.plist",
-      "target": "dmg"
-    },
-    "dmg": {
-      "writeUpdateInfo": false
+      "entitlementsInherit": "scripts/entitlements.mac.plist"
     },
     "linux": {
       "artifactName": "${name}-${version}-${os}-${arch}.${ext}",


### PR DESCRIPTION
A change in github runners left the macos x64 running on the wrong architecture. Apparently the `macos-14` runner is only arm now and silently ignores host option?