### PR TITLE
fix an issue with pyodide and symlinks

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "grist-desktop",
   "productName": "Grist Desktop",
   "description": "Grist Desktop",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "main": "core/_build/ext/app/electron/main.js",
   "repository": "https://github.com/gristlabs/grist-desktop",
   "author": "Grist Labs Inc. <info@getgrist.com>",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -143,8 +143,17 @@ echo ""
 echo "======================================================================="
 echo "Configure Grist to include external Electron code during build"
 
+# We basically want core/ext to be a link to ext, for a lightly
+# customized build of Grist. But there are two relative symlinks in ext to
+# version information that now confuse the electron builder. So we make
+# core/ext a real directory and place symlinks within it. Electron builder
+# appears to cope okay with this. Links are absolute and unnested to make
+# Windows happy.
 rm -rf core/ext
-ln -s ../ext core/ext
+mkdir core/ext
+for f in $(cd ext; ls); do
+  ln -s $(readlink -f $PWD/ext/$f) core/ext/$f
+done
 
 echo ""
 echo "======================================================================="


### PR DESCRIPTION
The desktop build has rusted again a little. Some symlinks to `package.json` used to get version information confuse the windows build. I worked around it with an ad-hoc workflow:

  https://github.com/gristlabs/grist-desktop/compare/main...paulfitz/windows-symlink

and this is an attempt to fix the original links. It works on test builds:

  https://github.com/gristlabs/grist-desktop/actions/runs/16730952994/job/47358642113