### PR TITLE
drop 32-bit windows, add a little more testing

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -38,10 +38,6 @@ jobs:
             node: 20
             host: arm64
             target: arm64
-          - os: windows-2022
-            node: 20
-            host: x64
-            target: x86
     name: ${{ matrix.os }} (node=${{ matrix.node }}, host=${{ matrix.host }}, target=${{ matrix.target }})
     steps:
       - name: Set up bash association
@@ -85,21 +81,8 @@ jobs:
 
       - name: Install dependencies
         if: steps.yarn-cache.outputs.cache-hit != 'true'
+        # skip optional dependencies because they add msgextract which fails on windows
         run: yarn install --network-timeout 300000 --ignore-optional
-
-      - name: Fix Windows x86 sqlite3 binding
-        if: steps.yarn-cache.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows') && matrix.target == 'x86'
-        run: |
-          yarn global add --network-timeout 600000 node-gyp node-pre-gyp node-gyp-build node-gyp-build-optional-packages
-          yarn upgrade sqlite3
-        # Prebuilt binding is for x64. We must build from source for x86 target.
-        # See:
-        # https://stackoverflow.com/questions/72553650/how-to-get-node-sqlite3-working-on-mac-m1
-        # https://yarnpkg.com/lang/en/docs/envvars/#toc-npm-config
-        env:
-          npm_config_build_from_source: true
-          npm_config_target_arch: ia32
-          npm_config_fallback_to_build: true
 
         # by not installing optional dependencies, we miss something
         # needed on macs

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "electron:linux": "electron-builder build --linux",
     "electron:ci": "./scripts/ci.sh",
     "electron": "electron-builder build --publish never",
-    "test": "electron core/_build/ext/app/electron/main.js --version"
+    "test": "./scripts/smoke-test.sh"
   },
   "resolutions": {
     "jquery": "3.5.0",

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -ex
+
+grist="electron core/_build/ext/app/electron/main.js"
+
+$grist --version
+$grist --cli sqlite query core/test/fixtures/docs/World.grist "select * from City limit 1"


### PR DESCRIPTION
32-bit build stopped working. Probably salvagable but the cost in time of keeping it going is significant. Going to drop support and see who complains. Usage of 32-bit windows has been dwindling for years.

In passing, make the tiny smoke test also exercise the part of Grist that reads a document, to exercise node-sqlite3, which is the most delicate part of the packaging historically.

This is done by supporting a `--cli` flag that, when supplied to the app, makes it operate like the cli companion app (it doesn't have a good name, but can be run as `yarn cli` if building from source, or `docker run --rm -v $PWD:$PWD -it gristlabs/grist cli -h`. Then the test can just run a `cli` command that touches an SQLite file. This repo isn't yet set up to do proper tests.