### PR TITLE
Fix opening documents on macOS

### DIFF
--- a/ext/app/electron/GristApp.ts
+++ b/ext/app/electron/GristApp.ts
@@ -251,14 +251,17 @@ export class GristApp {
 
   /**
    * Opens the file at filepath. File can be a Grist document, or an importable document.
-   * @param filePath Path to the file to open. Can be relative.
+   * @param filePath Absolute path to the file to open. Relative paths must be resolved by the
+   *                 caller, while the working directory is still meaningful: starting the Grist
+   *                 server chdirs to the app root, so resolving here would give the wrong file.
    * @param requestWindow The window associated with the open request. If this window is not showing
    *                      a document already, it will be reused for the newly opened document.
    */
   public async openFile(filePath: string, requestWindow?: electron.BrowserWindow) {
 
-    // Use absolute path only from now on.
-    filePath = path.resolve(filePath);
+    if (!path.isAbsolute(filePath)) {
+      throw new Error(`Cannot open ${filePath}: expected an absolute path`);
+    }
     const ext = path.extname(filePath);
 
     if (ext === ".grist") {

--- a/ext/app/electron/GristApp.ts
+++ b/ext/app/electron/GristApp.ts
@@ -69,7 +69,11 @@ export class GristApp {
     return gristUrl.doc !== undefined;
   }
 
-  public async run(initialFileToOpen: string|null) {
+  /**
+   * @param getInitialFileToOpen Read lazily, once startup is complete: on macOS the `open-file`
+   * event may only arrive while the async startup below is still in progress.
+   */
+  public async run(getInitialFileToOpen: () => string|null) {
 
     electron.app.on("second-instance", (_e, _argv, _cwd, _additionalData) => {
       const instanceHandoverInfo = _additionalData as InstanceHandoverInfo;
@@ -180,11 +184,12 @@ export class GristApp {
       callback({requestHeaders: details.requestHeaders});
     });
 
-    if (initialFileToOpen === null) {
+    const fileToOpen = getInitialFileToOpen();
+    if (fileToOpen === null) {
       this.windowManager.add(null);
     } else {
       try {
-        await this.openFile(initialFileToOpen);
+        await this.openFile(fileToOpen);
       } catch(e) {
         this.windowManager.add(null);
         electron.dialog.showErrorBox("Cannot open file", (e as Error).message);

--- a/ext/app/electron/main.ts
+++ b/ext/app/electron/main.ts
@@ -84,7 +84,11 @@ electronProgram
         console.error(e);
       }
     }
-    initialFileToOpen = docPath ?? null;
+    // Only when argv actually carried a path: on macOS it arrives via `open-file` instead,
+    // and must not be clobbered here.
+    if (docPath !== undefined) {
+      initialFileToOpen = docPath;
+    }
   });
 
 if (IS_TEST_MODE) {
@@ -114,7 +118,8 @@ async function main() {
     await loadConfig();
     try {
       setupLogging();
-      GristApp.instance.run(initialFileToOpen);
+      // Passed as a getter, not a value: `open-file` may still land during startup.
+      GristApp.instance.run(() => initialFileToOpen);
     } catch(err) {
       log.error(`Failed to load config, aborting: ${err}`);
       process.exit(1);

--- a/ext/app/electron/main.ts
+++ b/ext/app/electron/main.ts
@@ -87,7 +87,10 @@ electronProgram
     // Only when argv actually carried a path: on macOS it arrives via `open-file` instead,
     // and must not be clobbered here.
     if (docPath !== undefined) {
-      initialFileToOpen = docPath;
+      // Resolve now, while the working directory is still the one the command was invoked from:
+      // starting the Grist server chdirs to the app root, so a relative path would resolve
+      // against that instead and we would silently create a new document there.
+      initialFileToOpen = path.resolve(docPath);
     }
   });
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -158,8 +158,9 @@ echo "Configure Grist to include external Electron code during build"
 # Windows happy.
 rm -rf core/ext
 mkdir core/ext
-for f in $(cd ext; ls); do
-  ln -s $(readlink -f $PWD/ext/$f) core/ext/$f
+for source in ext/*; do
+  f=$(basename "$source")
+  ln -s "$(realpath "$source")" "core/ext/$f"
 done
 
 echo ""


### PR DESCRIPTION
I have fixed building Grist Desktop on macOS according to existing README.md instruction, then fixed opening documents from Finder, then fixed opening documents from command line (if anybody uses that way directly executing the binary without `open` command). 

I did not test it on Linux and Windows, only tested on macOS Tahoe 26.6.1.