### PR TITLE
v0.3.15

### DIFF
--- a/metadata/com.getgrist.grist.metainfo.xml
+++ b/metadata/com.getgrist.grist.metainfo.xml
@@ -66,6 +66,12 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.3.15" date="2026-09-10">
+      <description>
+        <p>Updates core Grist version to v1.7.19</p>
+        <p>Fixes opening documents from Finder on macOS</p>
+      </description>
+    </release>
     <release version="0.3.14" date="2026-08-03">
       <description>
         <p>Updates core Grist version to v1.7.17</p>

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "grist-desktop",
   "productName": "Grist Desktop",
   "description": "Grist Desktop",
-  "version": "0.3.14",
+  "version": "0.3.15",
   "main": "core/_build/ext/app/electron/main.js",
   "repository": "https://github.com/gristlabs/grist-desktop",
   "author": "Grist Labs Inc. <info@getgrist.com>",


### PR DESCRIPTION
Version bump for the v1.7.19 core release, and for the macOS document opening
fix in #136.

Core moves from v1.7.17 to v1.7.19 plus a few later commits.